### PR TITLE
download throttle

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -301,6 +301,15 @@ function makeResultsTable (results) {
 function removeFromName(name) {
   return name.replace(config.removeFromName, '')
 }
+function chunk(arr, chunkSize) {
+  let chunks = [], i = 0;
+
+  while(i < arr.length) {
+    chunks.push(arr.slice(i, i += chunkSize))
+  }
+
+  return chunks;
+}
 function exportIcons () {
   getFigmaFile()
     .then((res) => {
@@ -309,14 +318,18 @@ function exportIcons () {
           console.log(`Api returned ${icons.length} icons\n`)
           createOutputDirectory()
           .then(() => {
-            deleteIcons().then(() => {
-              spinner.start('Downloading')
-              const AllIcons = icons.map(icon => downloadImage(icon.image, removeFromName(icon.name)))
-              // const AllIcons = []
-              Promise.all(AllIcons).then((res) => {
-                spinner.succeed(chalk.cyan.bold('Download Finished!\n'))
-                console.log(`${makeResultsTable(res)}\n`)
-              })
+            deleteIcons().then(async () => {
+              spinner.start('Downloading chunks')
+              const chunks = chunk(icons, config.maxConcurrentConnections || defaults.maxConcurrentConnections);
+              let allIcons = [];
+              for(let i = 0; i<chunks.length; i++) {
+                spinner.start(`Downloading chunks ${i} of ${chunks.length}`);
+                const chunkPromise = chunks[i].map(icon => downloadImage(icon.image, removeFromName(icon.name)));
+                const chunkIcons = await Promise.all(chunkPromise);
+                allIcons = allIcons.concat(chunkIcons);
+              }
+              spinner.succeed(chalk.cyan.bold('Download Finished!\n'))
+              console.log(`${makeResultsTable(allIcons)}\n`)
             })
           })
         })

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -4,7 +4,8 @@ const defaults = {
   frame: 'Icons',
   iconsPath: 'assets/svg/icons',
   removeFromName: 'Icon=',
-  exportVariants: false
+  exportVariants: false,
+  maxConcurrentConnections: 500
 }
 
 module.exports = defaults

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -38,6 +38,14 @@ const prompts = [
     initial: defaults.exportVariants,
     active: 'yes',
     inactive: 'no'
+  },
+  {
+    type: 'number',
+    name: 'maxConcurrentConnections',
+    message: 'Maximum amount of concurrent S3 connections',
+    initial: defaults.maxConcurrentConnections,
+    min: 1,
+    max: 1000
   }
 ]
 


### PR DESCRIPTION
There were issues when this script was requesting 400 icons at nearly the same time from S3.  

Debugging with throttling the requests caused the ECONNRESET to go away.

Added the ability to set the chunk size that the icons are requested in.  Default is 500.

For us we needed below 200 for whatever reason.